### PR TITLE
Fix for Issue #7 where the changes to a data definition were not refl…

### DIFF
--- a/Common/CommonObject.cs
+++ b/Common/CommonObject.cs
@@ -30,6 +30,12 @@ namespace TNDStudios.DataPortals
         public String Description { get; set; }
 
         /// <summary>
+        /// The last time that this object was updated
+        /// </summary>
+        [JsonProperty]
+        public DateTime LastUpdated { get; set; }
+
+        /// <summary>
         /// Default Constructor
         /// </summary>
         public CommonObject()
@@ -37,6 +43,7 @@ namespace TNDStudios.DataPortals
             Id = Guid.NewGuid();
             Name = "";
             Description = "";
+            LastUpdated = DateTime.Now; // Default value (Mainly used for refreshing caches)
         }
     }
 }

--- a/Common/Packages/Package.cs
+++ b/Common/Packages/Package.cs
@@ -189,6 +189,7 @@ namespace TNDStudios.DataPortals.Repositories
                             // Assign the values from the item to save
                             existingApiDefinition.Description = apiDefinition.Description;
                             existingApiDefinition.Name = apiDefinition.Name;
+                            existingApiDefinition.LastUpdated = DateTime.Now;
 
                             // Assign the foreign keys
                             existingApiDefinition.DataConnection = apiDefinition.DataConnection;
@@ -231,6 +232,7 @@ namespace TNDStudios.DataPortals.Repositories
                             existingDataItemDefinition.Name = dataItemDefinition.Name;
                             existingDataItemDefinition.Culture = dataItemDefinition.Culture;
                             existingDataItemDefinition.EncodingFormat = dataItemDefinition.EncodingFormat;
+                            existingDataItemDefinition.LastUpdated = DateTime.Now;
 
                             // Assign the lists
                             existingDataItemDefinition.ItemProperties = dataItemDefinition.ItemProperties;
@@ -273,9 +275,7 @@ namespace TNDStudios.DataPortals.Repositories
                             existingConnection.Description = connection.Description;
                             existingConnection.Name = connection.Name;
                             existingConnection.ProviderType = connection.ProviderType;
-
-                            // Note: For now don't re-assign the definitions
-                            //existingConnection.Definitions = connection.Definitions;
+                            existingConnection.LastUpdated = DateTime.Now;                            
                         }
 
                         // Convert the data back to the return data type (which is actually the same)
@@ -311,7 +311,8 @@ namespace TNDStudios.DataPortals.Repositories
                         {
                             // Assign the values from the item to save
                             existingTransformation.Description = transformation.Description;
-                            existingTransformation.Name = transformation.Name;                           
+                            existingTransformation.Name = transformation.Name;
+                            existingTransformation.LastUpdated = DateTime.Now;
                         }
 
                         // Convert the data back to the return data type (which is actually the same)

--- a/Core/Data/DataProviderFactory.cs
+++ b/Core/Data/DataProviderFactory.cs
@@ -78,8 +78,13 @@ namespace TNDStudios.DataPortals.Data
             if (result != null)
             {
                 // Set the provider to be connected if it is not already connected
-                if (!result.Connected && definition != null)
-                    result.Connect(definition, connection.ConnectionString);
+                // or if the provider has an updated definition
+                if ((!result.Connected || (result.LastAction <= definition.LastUpdated))
+                    && definition != null)
+                {
+                    result.Connect(definition, connection.ConnectionString); // Connect attempt
+                    existingProvider = false; // Re-connected potentially so reset to make sure it's added to the cache
+                }
 
                 // If the provider was not in the pooled collection of providers then add it
                 if (!existingProvider && addToCache)

--- a/UI/Models/Api/CommonObjectModel.cs
+++ b/UI/Models/Api/CommonObjectModel.cs
@@ -31,11 +31,18 @@ namespace TNDStudios.DataPortals.UI.Models.Api
         public String Description { get; set; }
 
         /// <summary>
+        /// The last time the object was updated
+        /// </summary>
+        [JsonProperty]
+        public DateTime LastUpdated { get; set; }
+
+        /// <summary>
         /// Default Constructor
         /// </summary>
         public CommonObjectModel()
         {
             Id = Guid.Empty; // No Id by default but not null too
+            LastUpdated = DateTime.Now; // Default date
         }
 
     }


### PR DESCRIPTION
…ected in api definitions etc. as the connection data was being cached. Adding a date stamp to work out if changes has been made allowed the cache to be refreshed.